### PR TITLE
feat(kotlin_language_server): Add storagePath to initilaztion options

### DIFF
--- a/lua/lspconfig/server_configurations/kotlin_language_server.lua
+++ b/lua/lspconfig/server_configurations/kotlin_language_server.lua
@@ -24,6 +24,11 @@ return {
     filetypes = { 'kotlin' },
     root_dir = util.root_pattern(unpack(root_files)),
     cmd = { bin_name },
+  init_options = {
+    -- followed https://github.com/fwcd/vscode-kotlin/pull/86/files
+    -- added in https://github.com/fwcd/kotlin-language-server/pull/337
+    storagePath = "~/kotin-cache/"
+  }
   },
   docs = {
     description = [[


### PR DESCRIPTION
feature was added in https://github.com/fwcd/kotlin-language-server/pull/337 to help with caching and speeding up the language server.


I did not find the feature documented in the LSP repo to link but it has been used in the vs code client like this: https://github.com/fwcd/vscode-kotlin/pull/86/files